### PR TITLE
Adjust header spacing and fix CTA links

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
     .nav-container {
       max-width: 1100px;
       margin: 0 auto;
-      padding: 1.2rem clamp(1.2rem, 3vw, 2.4rem);
+      padding: 0.85rem clamp(1rem, 2.5vw, 2rem);
       display: flex;
       align-items: center;
       justify-content: space-between;
@@ -90,6 +90,13 @@
       transition: transform 220ms ease, box-shadow 220ms ease;
     }
 
+    header .btn-primary {
+      padding: 0.65rem 1.3rem;
+      font-size: 0.9rem;
+      font-weight: 500;
+      box-shadow: 0 10px 28px -22px rgba(75, 68, 128, 0.55);
+    }
+
     .btn-primary:hover,
     .btn-primary:focus-visible {
       transform: translateY(-2px) scale(1.02);
@@ -129,7 +136,7 @@
 
     .hero-text h1 {
       font-family: 'Playfair Display', serif;
-      font-size: clamp(2.6rem, 6vw, 3.6rem);
+      font-size: clamp(2.3rem, 5.2vw, 3.2rem);
       line-height: 1.1;
       margin: 0;
     }
@@ -454,7 +461,7 @@
         <a href="#journey">Nasıl işler?</a>
         <a href="#trust">Güven</a>
       </nav>
-      <a class="btn-primary" href="#cta">Yolculuğa Başla</a>
+      <a class="btn-primary" href="https://beta.chiron.com.tr" target="_blank" rel="noopener">Yolculuğa Başla</a>
     </div>
   </header>
 
@@ -471,7 +478,7 @@
         <h1>İçindeki Şifacıyı Keşfet.</h1>
         <p>Dinleyen, anlayan ve içsel yolculuğunda yanında olan akıllı rehber; mucizeyi senin ortaya çıkarabileceğine inanıyor. Her adımın, kendi dönüşümün için nazik bir davet.</p>
         <div class="hero-actions">
-          <a class="btn-primary" href="#cta">Ruhsal iyi halin için yolculuğuna bugün başla</a>
+          <a class="btn-primary" href="https://beta.chiron.com.tr" target="_blank" rel="noopener">Ruhsal iyi halin için yolculuğuna bugün başla</a>
           <a class="btn-secondary" href="#journey">Nasıl ilerliyoruz?</a>
         </div>
       </div>
@@ -564,7 +571,7 @@
       <div class="cta-final">
         <h2 class="section-title">Bir sıfırdan büyüktür.</h2>
         <p>En küçük pratik bile iyiliğine doğru bir adımdır. Kendi iyilik hâlini inşa etmeye bugün başla; bu adım sadece sana değil, iyileşen bir topluma da ışık olur.</p>
-        <a class="btn-primary" href="#hero">ÜCRETSİZ – Hemen Başla</a>
+        <a class="btn-primary" href="https://beta.chiron.com.tr" target="_blank" rel="noopener">ÜCRETSİZ – Hemen Başla</a>
       </div>
     </section>
   </main>


### PR DESCRIPTION
## Summary
- slim down the sticky header and hero title sizing for a lighter first impression
- point all "başla" call-to-action buttons back to https://beta.chiron.com.tr in a new tab

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68dad0abc924832294f2d2cb32cc2db8